### PR TITLE
varstore-sb-state: only load auth data if needed

### DIFF
--- a/tools/varstore-sb-state.c
+++ b/tools/varstore-sb-state.c
@@ -92,7 +92,8 @@ int main(int argc, char **argv)
     if (opt_socket)
         db->parse_arg("socket", opt_socket);
 
-    load_auth_data();
+    if (!strcmp(argv[optind + 1], "user"))
+        load_auth_data();
 
     if (!drop_privileges(opt_chroot, opt_depriv, opt_gid, opt_uid))
         exit(1);


### PR DESCRIPTION
The loaded auth data is only necessary when calling varstore-sb-state
user, so only call load_one_auth_data() if varstore-sb-state user is
called.

This avoids varstore-sb-state ${uuid} setup from attempting to load auth
files, which it doesn't actually need, and therefore avoids unnecessary
complaints if there happens to be one or more missing auth files.