### PR TITLE
xapidb_init: Use BACKEND_INIT_FAILURE

### DIFF
--- a/xapidb-lib.c
+++ b/xapidb-lib.c
@@ -754,7 +754,7 @@ xapidb_init(void)
         ERR("Failed to create BIO\n");
         free(encoded);
         free(buf);
-        return 1;
+        return BACKEND_INIT_FAILURE;
     }
     b64 = BIO_new(BIO_f_base64());
     if (!b64) {
@@ -762,7 +762,7 @@ xapidb_init(void)
         free(encoded);
         free(buf);
         BIO_free_all(bio);
-        return 1;
+        return BACKEND_INIT_FAILURE;
     }
     BIO_push(b64, bio);
     BIO_set_flags(b64, BIO_FLAGS_BASE64_NO_NL);


### PR DESCRIPTION
The return of 1 is wrong for these two failure cases since 1 is actually
BACKEND_INIT_SUCCESS.  Switch to the enum value for failure.

This is untested.  OpenXT is incorporating varstored with a custom backend, and I noticed this during review of the OpenXT code.