### PR TITLE
CP-41616: varstored should always read from new varstored_dir

### DIFF
--- a/handler.c
+++ b/handler.c
@@ -144,7 +144,7 @@ static const uint8_t EFI_IMAGE_SECURITY_DATABASE[] = {'d',0,'b',0};
 static const uint8_t EFI_IMAGE_SECURITY_DATABASE1[] = {'d',0,'b',0,'x',0};
 static const uint8_t EFI_IMAGE_SECURITY_DATABASE2[] = {'d',0,'b',0,'t',0};
 
-#define AUTH_PATH_PREFIX "/usr/share/varstored"
+#define AUTH_PATH_PREFIX "/var/lib/varstored"
 
 /*
  * Array of auth_info structs containing the information about the keys


### PR DESCRIPTION
This is the smallest change to conform with the design in https://github.com/xapi-project/xen-api/issues/4822

In the future, varstored could accept either a CLI parameter or a configuration file that sets the location of this directory.

Signed-off-by: Marcus Granado <marcus.granado@citrix.com>