### PR TITLE
Fix varstore-sb-state exit code

### DIFF
--- a/tools/varstore-sb-state.c
+++ b/tools/varstore-sb-state.c
@@ -112,7 +112,7 @@ int main(int argc, char **argv)
     do_rm(&gEfiImageSecurityDatabaseGuid, "dbx");
 
     if (!strcmp(argv[optind + 1], "user"))
-        return setup_keys();
+        return (setup_keys() ? 0 : 1);
     else
         return 0;
 }


### PR DESCRIPTION
In 'user' mode, varstore-sb-state exit code is the returned value of the function setup_keys() which returns true on success and false otherwise. The exit code is then 1 on success and 0 on failure, the opposite of the 'setup' mode.

This patch fixes the exit code, returning 0 when setup_keys() succeeds and 1 otherwise.