### PR TITLE
Auth: Add support to make only the PK file required

### DIFF
--- a/handler.c
+++ b/handler.c
@@ -147,6 +147,14 @@ static const uint8_t EFI_IMAGE_SECURITY_DATABASE2[] = {'d',0,'b',0,'t',0};
 
 #define AUTH_PATH_PREFIX "/var/lib/varstored"
 
+#ifdef AUTH_ONLY_PK_REQUIRED
+#define AUTH_DB_REQUIRED false
+#define AUTH_KEK_REQUIRED false
+#else
+#define AUTH_DB_REQUIRED true
+#define AUTH_KEK_REQUIRED true
+#endif
+
 /*
  * Array of auth_info structs containing the information about the keys
  * we need. Avoid switching to user mode before importing other keys by
@@ -157,9 +165,9 @@ static struct auth_info auth_info[] = {
     {"dbx", EFI_IMAGE_SECURITY_DATABASE1, sizeof(EFI_IMAGE_SECURITY_DATABASE1),
      &gEfiImageSecurityDatabaseGuid, AUTH_PATH_PREFIX "/dbx.auth", true, false},
     {"db", EFI_IMAGE_SECURITY_DATABASE, sizeof(EFI_IMAGE_SECURITY_DATABASE),
-     &gEfiImageSecurityDatabaseGuid, AUTH_PATH_PREFIX "/db.auth", false, true},
+     &gEfiImageSecurityDatabaseGuid, AUTH_PATH_PREFIX "/db.auth", false, AUTH_DB_REQUIRED},
     {"KEK", EFI_KEY_EXCHANGE_KEY_NAME, sizeof(EFI_KEY_EXCHANGE_KEY_NAME),
-     &gEfiGlobalVariableGuid, AUTH_PATH_PREFIX "/KEK.auth", false, true},
+     &gEfiGlobalVariableGuid, AUTH_PATH_PREFIX "/KEK.auth", false, AUTH_KEK_REQUIRED},
     {"PK", EFI_PLATFORM_KEY_NAME, sizeof(EFI_PLATFORM_KEY_NAME),
      &gEfiGlobalVariableGuid, AUTH_PATH_PREFIX "/PK.auth", false, true},
 };


### PR DESCRIPTION
If the host doesn't have the authentication files correctly configured for secure boot, the VM NVRAM state is always in setup mode and allows the VM to boot even if it has SecureBoot enabled.

This change allows varstored and varstore-sb-state to copy only the PK file (which is always present) and switch the VM to user mode. This will prevent the VM to boot if it has SecureBoot enabled, which is fine. Otherwise, the VM is stuck in setup mode allowing it to boot but with SecureBoot disabled, giving a false impression of security.

It's opt-out by default so DB and KEK files are set to not required only if the build macro AUTH_ONLY_PK_REQUIRED is defined.