### PR TITLE
CA-427740: Add missing barrier to avoid TOCTOU issue

### DIFF
--- a/include/serialize.h
+++ b/include/serialize.h
@@ -90,6 +90,7 @@ static inline void
 serialize_boolean(uint8_t **ptr, BOOLEAN var)
 {
     memcpy(*ptr, &var, sizeof(var));
+    barrier();
     *ptr += sizeof var;
 }
 


### PR DESCRIPTION
53c5965fcf5b0552900de3d8d6e5bd5d6f5a0bea introduced a `serialize_boolean` function, without a `barrier()` call, which is required to avoid re-introducing an XSA-478 TOCTOU issue.